### PR TITLE
add github_api_endpoint validation and testing

### DIFF
--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -256,14 +256,13 @@ func (src *Source) Validate() error {
 		return fmt.Errorf("source: missing keys: %s", strings.Join(mandatory, ", "))
 	}
 
-	//
 	// Validate optional fields.
-	//
-	// In this case, nothing to validate.
-
-	// todo: Validate that the github_api_endpoint is a valid URL with a protocol if it is provided
-	// todo: add a test for this validation in protocol_test.go
-
+	if src.GithubApiEndpoint != "" {
+		if !(strings.HasPrefix(src.GithubApiEndpoint, "https://")) {
+			return fmt.Errorf("source: github_api_endpoint %s must start with the https prefix", src.GithubApiEndpoint)
+		}
+	}
+	
 	//
 	// Apply defaults.
 	//

--- a/cogito/protocol.go
+++ b/cogito/protocol.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"net/url"
 
 	"github.com/Pix4D/cogito/sets"
 )
@@ -258,10 +259,16 @@ func (src *Source) Validate() error {
 
 	// Validate optional fields.
 	if src.GithubApiEndpoint != "" {
-		if !(strings.HasPrefix(src.GithubApiEndpoint, "https://")) {
-			return fmt.Errorf("source: github_api_endpoint %s must start with the https prefix", src.GithubApiEndpoint)
+		u, err := url.ParseRequestURI(src.GithubApiEndpoint)
+		if err != nil || u.Host == ""{
+			return fmt.Errorf("source: github_api_endpoint %s is an invalid api endpoint", src.GithubApiEndpoint)
 		}
-	}
+		if u.Scheme != "https" { //catch http prefix that falls through
+			return fmt.Errorf("source: github_api_endpoint %s must have a https prefix, not http", src.GithubApiEndpoint)
+		}
+	}	
+ 
+	fmt.Println("All ok")
 	
 	//
 	// Apply defaults.

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -111,14 +111,44 @@ func TestSourceValidationFailure(t *testing.T) {
 			wantErr: "source: invalid sink(s): [closed coffee shop]",
 		},
 		{
-			name: "invalid https protocol prefix in git source github_api_endpoint",
+			name: "no protocol prefix in git source github_api_endpoint",
 			source: cogito.Source{
 				Owner:        		"the-owner",
 				Repo:         		"the-repo",
 				AccessToken:  		"the-token",
 				GithubApiEndpoint: 	"github.coffee.com/api/v3",
 			},
-			wantErr: "source: github_api_endpoint github.coffee.com/api/v3 must start with the https prefix",
+			wantErr: "source: github_api_endpoint github.coffee.com/api/v3 is an invalid api endpoint",
+		},
+		{
+			name: "invalid http protocol prefix in git source github_api_endpoint",
+			source: cogito.Source{
+				Owner:        		"the-owner",
+				Repo:         		"the-repo",
+				AccessToken:  		"the-token",
+				GithubApiEndpoint: 	"http://github.coffee.com/api/v3",
+			},
+			wantErr: "source: github_api_endpoint http://github.coffee.com/api/v3 must have a https prefix, not http",
+		},
+		{
+			name: "invalid http protocol prefix in git source github_api_endpoint",
+			source: cogito.Source{
+				Owner:        		"the-owner",
+				Repo:         		"the-repo",
+				AccessToken:  		"the-token",
+				GithubApiEndpoint: 	"https:github.coffee.com/api/v3",
+			},
+			wantErr: "source: github_api_endpoint https:github.coffee.com/api/v3 is an invalid api endpoint",
+		},
+		{
+			name: "invalid http protocol prefix in git source github_api_endpoint",
+			source: cogito.Source{
+				Owner:        		"the-owner",
+				Repo:         		"the-repo",
+				AccessToken:  		"the-token",
+				GithubApiEndpoint: 	"john.smith.cim",
+			},
+			wantErr: "source: github_api_endpoint john.smith.cim is an invalid api endpoint",
 		},
 	}
 

--- a/cogito/protocol_test.go
+++ b/cogito/protocol_test.go
@@ -46,6 +46,14 @@ func TestSourceValidationSuccess(t *testing.T) {
 				return source
 			},
 		},
+		{
+			name: "optional git source github_api_endpoint",
+			mkSource: func() cogito.Source{
+				source := baseGithubSource
+				source.GithubApiEndpoint = "https://github.coffee.com/api/v3"
+				return source
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -101,6 +109,16 @@ func TestSourceValidationFailure(t *testing.T) {
 				AccessToken:  "the-token",
 			},
 			wantErr: "source: invalid sink(s): [closed coffee shop]",
+		},
+		{
+			name: "invalid https protocol prefix in git source github_api_endpoint",
+			source: cogito.Source{
+				Owner:        		"the-owner",
+				Repo:         		"the-repo",
+				AccessToken:  		"the-token",
+				GithubApiEndpoint: 	"github.coffee.com/api/v3",
+			},
+			wantErr: "source: github_api_endpoint github.coffee.com/api/v3 must start with the https prefix",
 		},
 	}
 


### PR DESCRIPTION
Add validation for the optional `github_api_endpoint` source key and add test cases.